### PR TITLE
Added tag creation for constants

### DIFF
--- a/src/gdtags.nim
+++ b/src/gdtags.nim
@@ -155,6 +155,7 @@ const
     "variable_statement": "variable",
     "export_variable_statement": "variable",
     "onready_variable_statement": "variable",
+    "const_statement": "constant",
     "function_definition": "function",
     "class_definition": "class",
     "enum_definition": "enumDef",


### PR DESCRIPTION
I have added tag creation for constants. They were omitted before (not even grouped as variables).